### PR TITLE
init migration duplicate roles fix

### DIFF
--- a/docker/setup_update.sh
+++ b/docker/setup_update.sh
@@ -10,41 +10,14 @@ if [ ! -s ".env" ]; then
 fi
 
 # Create the authentication roles script first (00-auth-roles.sql)
-cat > volumes/db/init/00-auth-roles.sql << 'EOL'
+cat > volumes/db/init/001-auth-roles.sql << 'EOL'
 -- Create all the necessary roles for Supabase and PostgREST
 DO $$
 BEGIN
-  -- First create the basic roles
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
-    CREATE ROLE anon;
-    RAISE NOTICE 'Created anon role';
-  END IF;
-
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
-    CREATE ROLE authenticated;
-    RAISE NOTICE 'Created authenticated role';
-  END IF;
-
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-    CREATE ROLE service_role;
-    RAISE NOTICE 'Created service_role role';
-  END IF;
-
-  -- Then create authenticator and grant the basic roles to it
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
-    CREATE ROLE authenticator WITH LOGIN;
-    RAISE NOTICE 'Created authenticator role';
-  END IF;
-  
   -- Create admin roles
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN
     CREATE ROLE supabase_admin WITH LOGIN SUPERUSER CREATEDB CREATEROLE REPLICATION BYPASSRLS;
     RAISE NOTICE 'Created supabase_admin role';
-  END IF;
-  
-  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
-    CREATE ROLE supabase_auth_admin WITH LOGIN;
-    RAISE NOTICE 'Created supabase_auth_admin role';
   END IF;
   
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN
@@ -52,14 +25,8 @@ BEGIN
     RAISE NOTICE 'Created supabase_storage_admin role';
   END IF;
 
-  -- Grant roles to authenticator
-  GRANT anon TO authenticator;
-  GRANT authenticated TO authenticator;
-  GRANT service_role TO authenticator;
-
   -- Grant privileges
   GRANT ALL PRIVILEGES ON DATABASE postgres TO supabase_admin;
-  GRANT USAGE ON SCHEMA public TO authenticator, anon, authenticated, service_role;
 
   RAISE NOTICE 'All roles created and configured successfully';
 END
@@ -99,12 +66,6 @@ BEGIN
     EXECUTE format('ALTER ROLE postgres WITH PASSWORD %L', postgres_password);
     RAISE NOTICE 'Set password for postgres';
     
-    -- Set password for other roles if they exist
-    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
-        EXECUTE format('ALTER ROLE supabase_auth_admin WITH PASSWORD %L', postgres_password);
-        RAISE NOTICE 'Set password for supabase_auth_admin';
-    END IF;
-    
     IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN
         EXECUTE format('ALTER ROLE supabase_storage_admin WITH PASSWORD %L', postgres_password);
         RAISE NOTICE 'Set password for supabase_storage_admin';
@@ -117,7 +78,7 @@ EOL
 
 # Download Supabase initialization scripts for the database
 echo "Downloading Supabase initialization scripts..."
-curl -s https://raw.githubusercontent.com/supabase/postgres/develop/migrations/db/init-scripts/00000000000000-initial-schema.sql > volumes/db/init/00-initial-schema.sql
+curl -s https://raw.githubusercontent.com/supabase/postgres/develop/migrations/db/init-scripts/00000000000000-initial-schema.sql > volumes/db/init/001-initial-schema.sql
 curl -s https://raw.githubusercontent.com/supabase/postgres/develop/migrations/db/init-scripts/00000000000001-auth-schema.sql > volumes/db/init/01-auth-schema.sql
 curl -s https://raw.githubusercontent.com/supabase/postgres/develop/migrations/db/init-scripts/00000000000003-post-setup.sql > volumes/db/init/03-post-setup.sql
 


### PR DESCRIPTION
Before 

```
/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/00-auth-roles.sql
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created anon role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created authenticated role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created service_role role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created authenticator role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created supabase_admin role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created supabase_auth_admin role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  Created supabase_storage_admin role
psql:/docker-entrypoint-initdb.d/00-auth-roles.sql:53: NOTICE:  All roles created and configured successfully
DO


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/00-initial-schema.sql
2026-06-16 22:19:20.167 UTC [62] WARNING:  wal_level is insufficient to publish logical changes
2026-06-16 22:19:20.167 UTC [62] HINT:  Set wal_level to "logical" before creating subscriptions.
psql:/docker-entrypoint-initdb.d/00-initial-schema.sql:5: WARNING:  wal_level is insufficient to publish logical changes
HINT:  Set wal_level to "logical" before creating subscriptions.
CREATE PUBLICATION
ALTER ROLE
CREATE ROLE
CREATE ROLE
GRANT ROLE
GRANT
CREATE ROLE
GRANT ROLE
CREATE SCHEMA
CREATE EXTENSION
CREATE EXTENSION
2026-06-16 22:19:20.207 UTC [62] ERROR:  role "anon" already exists
2026-06-16 22:19:20.207 UTC [62] STATEMENT:  create role anon                nologin noinherit;
psql:/docker-entrypoint-initdb.d/00-initial-schema.sql:29: ERROR:  role "anon" already exists

PostgreSQL Database directory appears to contain a database; Skipping initialization

2026-06-16 22:19:20.567 UTC [1] LOG:  starting PostgreSQL 15.8 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 13.2.0, 64-bit
2026-06-16 22:19:20.567 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2026-06-16 22:19:20.568 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2026-06-16 22:19:20.578 UTC [1] LOG:  listening on Unix socket "/run/postgresql/.s.PGSQL.5432"
2026-06-16 22:19:20.590 UTC [29] LOG:  database system was interrupted; last known up at 2026-06-16 22:19:20 UTC
2026-06-16 22:19:20.625 UTC [29] LOG:  database system was not properly shut down; automatic recovery in progress
2026-06-16 22:19:20.631 UTC [29] LOG:  redo starts at 0/1501380
2026-06-16 22:19:20.632 UTC [29] LOG:  invalid record length at 0/15580B8: wanted 24, got 0
2026-06-16 22:19:20.632 UTC [29] LOG:  redo done at 0/1557988 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s
2026-06-16 22:19:20.643 UTC [27] LOG:  checkpoint starting: end-of-recovery immediate wait
2026-06-16 22:19:20.684 UTC [27] LOG:  checkpoint complete: wrote 81 buffers (0.5%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.012 s, sync=0.009 s, total=0.046 s; sync files=38, longest=0.004 s, average=0.001 s; distance=347 kB, estimate=347 kB
2026-06-16 22:19:20.693 UTC [1] LOG:  database system is ready to accept connections
2026-06-16 22:19:26.180 UTC [40] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:26.180 UTC [40] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:26.465 UTC [41] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:26.465 UTC [41] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:26.918 UTC [42] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:26.918 UTC [42] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:27.544 UTC [43] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:27.544 UTC [43] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:29.532 UTC [44] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:29.532 UTC [44] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:30.176 UTC [45] FATAL:  password authentication failed for user "supabase_admin"
2026-06-16 22:19:30.176 UTC [45] DETAIL:  User "supabase_admin" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:31.223 UTC [46] FATAL:  password authentication failed for user "supabase_admin"
2026-06-16 22:19:31.223 UTC [46] DETAIL:  User "supabase_admin" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:31.325 UTC [47] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:31.325 UTC [47] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:34.770 UTC [48] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:34.770 UTC [48] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
2026-06-16 22:19:41.357 UTC [49] FATAL:  password authentication failed for user "authenticator"
2026-06-16 22:19:41.357 UTC [49] DETAIL:  User "authenticator" has no password assigned.
	Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
```

After

```/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/001-auth-roles.sql
psql:/docker-entrypoint-initdb.d/001-auth-roles.sql:53: NOTICE:  Created supabase_admin role
psql:/docker-entrypoint-initdb.d/001-auth-roles.sql:53: NOTICE:  Created supabase_storage_admin role
psql:/docker-entrypoint-initdb.d/001-auth-roles.sql:53: NOTICE:  All roles created and configured successfully
DO


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/001-initial-schema.sql
psql:/docker-entrypoint-initdb.d/001-initial-schema.sql:5: WARNING:  wal_level is insufficient to publish logical changes
HINT:  Set wal_level to "logical" before creating subscriptions.
2026-06-16 22:23:42.227 UTC [54] WARNING:  wal_level is insufficient to publish logical changes
2026-06-16 22:23:42.227 UTC [54] HINT:  Set wal_level to "logical" before creating subscriptions.
CREATE PUBLICATION
ALTER ROLE
CREATE ROLE
CREATE ROLE
GRANT ROLE
GRANT
CREATE ROLE
GRANT ROLE
CREATE SCHEMA
CREATE EXTENSION
CREATE EXTENSION
CREATE ROLE
CREATE ROLE
CREATE ROLE
CREATE ROLE
GRANT ROLE
GRANT ROLE
GRANT ROLE
GRANT ROLE
GRANT
ALTER DEFAULT PRIVILEGES
ALTER DEFAULT PRIVILEGES
ALTER DEFAULT PRIVILEGES
GRANT
ALTER ROLE
ALTER DEFAULT PRIVILEGES
ALTER DEFAULT PRIVILEGES
ALTER DEFAULT PRIVILEGES
ALTER ROLE
ALTER ROLE


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/01-auth-schema.sql
CREATE SCHEMA
CREATE TABLE
CREATE INDEX
CREATE INDEX
COMMENT
CREATE TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
COMMENT
CREATE TABLE
COMMENT
CREATE TABLE
CREATE INDEX
COMMENT
CREATE TABLE
COMMENT
INSERT 0 7
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION
GRANT
CREATE ROLE
GRANT
GRANT
GRANT
ALTER ROLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/03-post-setup.sql
ALTER ROLE
ALTER ROLE
CREATE FUNCTION
CREATE EVENT TRIGGER
COMMENT
CREATE FUNCTION
COMMENT
DO
CREATE ROLE
GRANT
GRANT
GRANT
GRANT
GRANT
GRANT
GRANT
GRANT
GRANT
DO


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/04-app-tables.sql
CREATE EXTENSION
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE FUNCTION
CREATE FUNCTION
CREATE FUNCTION


/usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/99-set-passwords.sql
2026-06-16 22:23:42.698 UTC [62] WARNING:  POSTGRES_PASSWORD environment variable not set, using default password
2026-06-16 22:23:42.698 UTC [62] CONTEXT:  PL/pgSQL function inline_code_block line 15 at RAISE
psql:/docker-entrypoint-initdb.d/99-set-passwords.sql:45: WARNING:  POSTGRES_PASSWORD environment variable not set, using default password
psql:/docker-entrypoint-initdb.d/99-set-passwords.sql:45: NOTICE:  Set password for supabase_admin
psql:/docker-entrypoint-initdb.d/99-set-passwords.sql:45: NOTICE:  Set password for authenticator
psql:/docker-entrypoint-initdb.d/99-set-passwords.sql:45: NOTICE:  Set password for postgres
psql:/docker-entrypoint-initdb.d/99-set-passwords.sql:45: NOTICE:  Set password for supabase_storage_admin
psql:/docker-entrypoint-initdb.d/99-set-passwords.sql:45: NOTICE:  All passwords set successfully
DO


waiting for server to shut down....2026-06-16 22:23:42.746 UTC [41] LOG:  received fast shutdown request
2026-06-16 22:23:42.750 UTC [41] LOG:  aborting any active transactions
2026-06-16 22:23:42.751 UTC [41] LOG:  background worker "logical replication launcher" (PID 47) exited with exit code 1
2026-06-16 22:23:42.751 UTC [42] LOG:  shutting down
2026-06-16 22:23:42.755 UTC [42] LOG:  checkpoint starting: shutdown immediate
2026-06-16 22:23:42.814 UTC [42] LOG:  checkpoint complete: wrote 285 buffers (1.7%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.013 s, sync=0.024 s, total=0.063 s; sync files=170, longest=0.006 s, average=0.001 s; distance=1579 kB, estimate=1579 kB
2026-06-16 22:23:42.819 UTC [41] LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

2026-06-16 22:23:42.909 UTC [1] LOG:  starting PostgreSQL 15.14 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 15.2.0, 64-bit
2026-06-16 22:23:42.910 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2026-06-16 22:23:42.910 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2026-06-16 22:23:42.920 UTC [1] LOG:  listening on Unix socket "/run/postgresql/.s.PGSQL.5432"
2026-06-16 22:23:42.932 UTC [67] LOG:  database system was shut down at 2026-06-16 22:23:42 UTC
2026-06-16 22:23:42.939 UTC [1] LOG:  database system is ready to accept connections
2026-06-16 22:23:47.086 UTC [78] ERROR:  schema "storage" does not exist
```



